### PR TITLE
Add trivy scan for the connector

### DIFF
--- a/.github/workflows/dev-stg-release.yml
+++ b/.github/workflows/dev-stg-release.yml
@@ -53,6 +53,16 @@ jobs:
         env:
           JAVA_HOME: /usr/lib/jvm/default-jvm
 
+      # Perform Trivy scan
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'rootfs'
+          scan-ref: '.'
+          format: 'table'
+          timeout: '10m0s'
+          exit-code: '1'
+
       # Push to Ballerina Staging Central
       - name: Push to Staging
         if: github.event.inputs.bal_central_environment == 'STAGE'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,16 @@ jobs:
         env:
           JAVA_HOME: /usr/lib/jvm/default-jvm
 
+      # Perform Trivy scan
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'rootfs'
+          scan-ref: '.'
+          format: 'table'
+          timeout: '10m0s'
+          exit-code: '1'
+
       # Push to Ballerina Central
       - name: Ballerina Push
         uses: ballerina-platform/ballerina-action/@2201.7.0

--- a/.github/workflows/trivy-scan.yml
+++ b/.github/workflows/trivy-scan.yml
@@ -1,0 +1,31 @@
+name: Trivy
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron:  '30 20 * * *'
+
+jobs:
+  ubuntu-build:
+    name: Build on Ubuntu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: 11
+      - name: Build with Gradle
+        env:
+          packageUser: ${{ github.actor }}
+          packagePAT: ${{ secrets.GITHUB_TOKEN }}
+        run: ./gradlew build -x check -x test
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          scan-type: 'rootfs'
+          scan-ref: '.'
+          format: 'table'
+          timeout: '10m0s'
+          exit-code: '1'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ Ballerina Snowflake Connector
 ===================
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-snowflake/workflows/CI/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-snowflake/actions?query=workflow%3ACI)
+[![Trivy](https://github.com/ballerina-platform/module-ballerinax-snowflake/actions/workflows/trivy-scan.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-snowflake/actions/workflows/trivy-scan.yml)
 [![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-snowflake.svg)](https://github.com/ballerina-platform/module-ballerinax-snowflake/commits/main)
 [![GraalVM Check](https://github.com/ballerina-platform/module-ballerinax-snowflake/actions/workflows/build-with-bal-test-native.yml/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-snowflake/actions/workflows/build-with-bal-test-native.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)


### PR DESCRIPTION
# Description

The PR adds Trivy scan for the connector to check and generate the security vulnerability report on demand or during releases. 

Related to https://github.com/ballerina-platform/ballerina-extended-library/issues/536 
